### PR TITLE
Update ospo-reusable-workflows to new GitHub org

### DIFF
--- a/.github/auto-labeler.yml
+++ b/.github/auto-labeler.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@26eec20abba5ae806698592c79628f6906da372c
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@26eec20abba5ae806698592c79628f6906da372c
     with:
       config-name: release-drafter.yml
     secrets:

--- a/.github/pr-title.yml
+++ b/.github/pr-title.yml
@@ -11,6 +11,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: write
-    uses: github/ospo-reusable-workflows/.github/workflows/pr-title.yaml@26eec20abba5ae806698592c79628f6906da372c
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@26eec20abba5ae806698592c79628f6906da372c
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: github/ospo-reusable-workflows/.github/workflows/release.yaml@26eec20abba5ae806698592c79628f6906da372c
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@26eec20abba5ae806698592c79628f6906da372c
     with:
       publish: true
       release-config-name: release-drafter.yml


### PR DESCRIPTION
## What
Updated GitHub Actions workflow references from `github/ospo-reusable-workflows` to `github-community-projects/ospo-reusable-workflows`.

## Why
The ospo-reusable-workflows repository has been transferred to the github-community-projects organization.

## Notes
- The SHA pins remain unchanged so the exact same code is referenced