### PR TITLE
chore(deps): upgrade Go to 1.26.2 and bump dependencies

### DIFF
--- a/.goreleaser.tmpl
+++ b/.goreleaser.tmpl
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.VersionPostfix=
+      - -X main.GitCommitHash={{.Commit}}
+      - -X main.BuiltAt={{.Date}}
+
+archives:
+  - formats: ["tar.gz"]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
+
+checksum:
+  name_template: "checksums.txt"
+
+sboms:
+  - artifacts: archive
+    cmd: syft
+    args: ["${artifact}", "--output", "spdx-json=${document}"]
+    documents:
+      - "${artifact}.spdx.json"
+
+changelog:
+  disable: true
+
+release:
+  mode: keep-existing
+
+universal_binaries:
+  - replace: true
+    name_template: {{ .ServiceName }}

--- a/go.mod.tmpl
+++ b/go.mod.tmpl
@@ -1,10 +1,10 @@
 module github.com/{{ .Organization }}/{{ .ServiceName }} // Replace this globally with your module name
 
-go 1.25.1
+go 1.26.2
 
 require (
-	github.com/gemaraproj/go-gemara v0.0.2
-	github.com/privateerproj/privateer-sdk v1.21.0
+	github.com/gemaraproj/go-gemara v0.3.0
+	github.com/privateerproj/privateer-sdk v1.23.1
 )
 
 require (
@@ -19,7 +19,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
-	github.com/go-git/go-git/v5 v5.17.0 // indirect
+	github.com/go-git/go-git/v5 v5.17.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect


### PR DESCRIPTION
## What

Upgraded Go version from 1.25.1 to 1.26.2, bumped privateer-sdk from v1.21.0 to v1.23.1, go-gemara from v0.0.2 to v0.3.0, and go-git from v5.17.0 to v5.17.2. Added `.goreleaser.tmpl` for plugin release builds.

## Why

Aligning plugin generator templates with the versions used in the privateer and privateer-sdk repositories after recent dependency upgrades.

## Notes

- The go-gemara jump from v0.0.2 to v0.3.0 is a significant version bump — generated plugins using go-gemara APIs directly should be verified against the v0.3.0 API surface
- The `.goreleaser.tmpl` is new and differs from pvtr's `.goreleaser.yaml` intentionally (e.g., checksum/sbom sections, changelog disabled, keep-existing release mode)
- This is a template-only repo with no compilable Go code — templates are rendered by the plugin generator at runtime

## Testing

- No tests to run — this repo contains only `.tmpl` files that are rendered by the plugin generator
- Verified dependency versions match pvtr (`v1.23.1` SDK, Go 1.26.2) and pvtr-sdk (`v0.3.0` go-gemara, Go 1.26.2)
- Verified `.goreleaser.tmpl` structure against pvtr's `.goreleaser.yaml`