### PR TITLE
fix: replace goreleaser tmpl with yaml placeholder and fix Imports field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,10 +23,10 @@ builds:
         goarch: "386"
     ldflags:
       - -s -w
-      - -X main.Version={{.Version}}
+      - -X main.Version={{ .Version }}
       - -X main.VersionPostfix=
-      - -X main.GitCommitHash={{.Commit}}
-      - -X main.BuiltAt={{.Date}}
+      - -X main.GitCommitHash={{ .Commit }}
+      - -X main.BuiltAt={{ .Date }}
 
 archives:
   - formats: ["tar.gz"]
@@ -59,4 +59,4 @@ release:
 
 universal_binaries:
   - replace: true
-    name_template: {{ .ServiceName }}
+    name_template: __SERVICE_NAME__

--- a/evaluation_plans/evaluation_plans.go.tmpl
+++ b/evaluation_plans/evaluation_plans.go.tmpl
@@ -16,7 +16,7 @@ var (
             reusable_steps.NotImplemented,
         },
         {{- end }}
-        {{ range .Imports.Controls }}
+        {{ range .Imports }}
         // {{ .ReferenceId }}
         {{- range .Entries }}
         "{{ .ReferenceId }}": {


### PR DESCRIPTION
## What

Renamed .goreleaser.tmpl to .goreleaser.yaml using `__SERVICE_NAME__` placeholder instead of Go template syntax. Fixed evaluation_plans.go.tmpl to range over `.Imports` directly instead of the nonexistent `.Imports.Controls` field.

## Why

The .goreleaser.tmpl mixed Go template directives with goreleaser's own template syntax, causing pvtr-sdk's template parser to fail on goreleaser functions like `title`. The Imports field on ControlCatalog is `[]MultiEntryMapping` which has no Controls sub-field, causing the evaluation_plans template to fail after the go-gemara v0.3.0 upgrade.

## Notes

- Requires companion change in privateerproj/privateer-sdk to replace `__SERVICE_NAME__` placeholder in non-template files during generation
- `__ORGANIZATION__` placeholder is also supported by pvtr-sdk for future use
- Any non-template file can now use these placeholders without conflicting with its own template syntax

## Testing

- Verified generated output from `pvtr generate-plugin` produces correct `.goreleaser.yaml` with service name injected and correct `evaluation_plans.go` with proper Imports iteration