### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.1

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,12 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
-      id-token: write
-      attestations: write
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      packages: write       # Push container image to ghcr.io
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate build provenance attestations
+      discussions: write    # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,73 +10,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc # v0.6.0
+      id-token: write
+      attestations: write
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yaml
+      goreleaser-config-path: .goreleaser.yaml
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  goreleaser:
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-    outputs:
-      attestation_matrix: ${{ steps.generate_matrix.outputs.matrix }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          syft-version: v1.33.0
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-checksums: dist/checksums.txt
-      - name: Generate attestation matrix
-        id: generate_matrix
-        run: |
-          matrix=$(ls dist/*.spdx.json | jq -R '{"sbom": ., "archive": sub("\\.spdx\\.json$"; "")}' | jq -s -c '{"include": .}')
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
-      - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dist
-          path: dist
-  attest-sboms:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      id-token: write
-    strategy:
-      matrix: ${{ fromJson(needs.goreleaser.outputs.attestation_matrix) }}
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist
-      - name: Attest SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
-        with:
-          subject-path: "${{ matrix.archive }}"
-          sbom-path: "${{ matrix.sbom }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate build provenance attestations
       discussions: write    # Create release announcement discussion
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yaml

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,7 @@ changelog:
   disable: true
 
 release:
+  disable: true
   mode: keep-existing
 
 universal_binaries:


### PR DESCRIPTION
## What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530), use the reusable workflow's built-in GoReleaser support, add `release.disable` to `.goreleaser.yaml`, and add a Breaking Changes category to release-drafter.

## Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. Centralizing the GoReleaser step removes duplicated CI definition and keeps version pins on a single hardened source.

## Notes

- The reusable workflow validates that the GoReleaser config sets `release.disable: true` to prevent the goreleaser step from racing the draft release.
- The outer label-filter `if:` block is removed because the v1.0 reusable workflow handles label filtering internally.
- Trigger updated to `pull_request_target` so the workflow can push tags via `GITHUB_TOKEN`.
- This is a templates repo with no real `go.mod` (only `go.mod.tmpl`), so `go-version-file` is omitted from the workflow `with:` inputs.
- The separate `goreleaser` and `attest-sboms` jobs are removed; the reusable workflow now performs GoReleaser, build provenance attestation, and SBOM handling internally.

## Testing

- [ ] Workflow syntax validates on GitHub (no parse errors on push)
- [ ] On next merged PR with a release-triggering label, the reusable workflow runs end-to-end and publishes a release with attestations
- [ ] GoReleaser does not attempt to create its own release (verified via `release.disable: true`)